### PR TITLE
Update converge.py

### DIFF
--- a/converge.py
+++ b/converge.py
@@ -59,7 +59,7 @@ def assign_read_counts(sampleID, readCounts, hits_info):
     ##   sequencially
     for readID in readIDs_tbd: #iterate over each multi-mapped read
         df = DF.loc[:, (DF.loc[readID] > 0)] #dataframe slice containing all reference columns that have nonzero values with this read
-        df = df.loc[(df != 0).any(1), :] #drop read rows that contain all zeros
+        df = df.loc[(df != 0).any(axis=1), :] #drop read rows that contain all zeros
         df_assigned = DF_assigned.loc[df.index, df.columns] #make a same slice the dataframe to hold normalized values
 
         rIDs = df.index.to_list() #all readIDs in this matrix (index)


### PR DESCRIPTION
Fix bug for new version of python
change 
```bash
df = df.loc[(df != 0).any(1), :]
```
to
```bash
df = df.loc[(df != 0).any(axis=1), :]
```

Traceback (most recent call last):
  File "/home/anegin97/miniconda3/lib/python3.11/concurrent/futures/process.py", line 261, in _process_worker
    r = call_item.fn(*call_item.args, **call_item.kwargs)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/media/anegin97/DATA/DATA/Metagenomic/oralmicrobiome/snapp-py3/16S-SNAPP-py3/converge.py", line 182, in converge
    refset, mapped_ASV_IDs = assign_read_counts(sample_id, sample_count_series, blastn_match_dict)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/media/anegin97/DATA/DATA/Metagenomic/oralmicrobiome/snapp-py3/16S-SNAPP-py3/converge.py", line 62, in assign_read_counts
    df = df.loc[(df != 0).any(1), :] #drop read rows that contain all zeros
                ^^^^^^^^^^^^^^^^
TypeError: DataFrame.any() takes 1 positional argument but 2 were given """

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/media/anegin97/DATA/DATA/Metagenomic/oralmicrobiome/snapp-py3/16S-SNAPP-py3/converge.py", line 276, in <module>
    all_completed.append(f.result())                                      #
                         ^^^^^^^^^^
  File "/home/anegin97/miniconda3/lib/python3.11/concurrent/futures/_base.py", line 449, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/home/anegin97/miniconda3/lib/python3.11/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
TypeError: DataFrame.any() takes 1 positional argument but 2 were given